### PR TITLE
feat: Initialize project with Network Policy Helm chart

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,12 @@
+# GitHub Actions Workflows
+
+This directory contains GitHub Actions workflow files (`.yml` or `.yaml`) for automating CI/CD processes.
+
+## Examples
+
+- **Build and Test:** A workflow that triggers on push/pull_request to build the application and run unit/integration tests.
+- **Linting:** A workflow to check code style and quality.
+- **Docker Build and Push:** A workflow to build Docker images and push them to a container registry (e.g., Docker Hub, GCR, ECR).
+- **Deploy to Staging/Production:** Workflows to deploy the application to different environments upon specific triggers (e.g., merge to main, tag creation).
+
+These workflows help in maintaining code quality, ensuring application stability, and automating the deployment pipeline.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+# GitHub Actions Workflow: Basic CI
+
+name: Basic CI
+
+on:
+  push:
+    branches: [ main, master, develop ] # Adjust branch names as needed
+  pull_request:
+    branches: [ main, master, develop ] # Adjust branch names as needed
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Frontend Build/Test (Example - customize for your framework)
+    - name: Setup Node.js (for Frontend)
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18' # Specify your Node.js version
+    - name: Install Frontend Dependencies
+      run: |
+        cd frontend
+        # npm install # Uncomment if you have a package.json
+        echo "Simulating frontend dependency installation"
+    - name: Run Frontend Linter/Tests (Placeholder)
+      run: |
+        cd frontend
+        # npm run lint # Uncomment and configure if you have a linter
+        # npm test # Uncomment and configure if you have tests
+        echo "Simulating frontend linting and tests"
+
+    # Backend Build/Test (Example - Python)
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.9' # Specify your Python version
+    - name: Install Backend Dependencies
+      run: |
+        cd backend
+        python -m pip install --upgrade pip
+        # pip install -r requirements.txt # Uncomment if you have dependencies
+        echo "Simulating backend dependency installation"
+    - name: Run Backend Linter/Tests (Placeholder)
+      run: |
+        cd backend
+        # pip install flake8 pytest # Example tools
+        # flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics # Example lint command
+        # pytest # Example test command
+        echo "Simulating backend linting and tests"
+
+    - name: Placeholder for Docker Build & Push
+      run: echo "In a real scenario, here you would build Docker images and push to a registry."
+
+    - name: Placeholder for K8s Deployment
+      run: echo "In a real scenario, here you might use kubectl or Helm to deploy to a K8s cluster."

--- a/README.md
+++ b/README.md
@@ -1,2 +1,154 @@
-# engineering-portfolio
-Created to commit my work to showcase
+# Full Stack & SRE Automation Engineer Portfolio
+
+Welcome to my portfolio project! This repository showcases a variety of skills relevant to a Full Stack Developer and Site Reliability Engineer (SRE), with a particular focus on Kubernetes, CI/CD, and automation.
+
+## Project Overview
+
+This project aims to demonstrate:
+
+*   **Frontend Development:** (Placeholder for a simple web application)
+*   **Backend Development:** (Placeholder for a supporting API)
+*   **Kubernetes:** Deployment manifests, service definitions, and crucially, **Network Policies**.
+*   **CI/CD Automation:** Example pipelines using GitHub Actions and Jenkins.
+*   **Infrastructure as Code (IaC) Principles:** Managing configurations through code.
+
+## Table of Contents
+
+*   [Project Structure](#project-structure)
+*   [Frontend](#frontend)
+*   [Backend](#backend)
+*   [Kubernetes Configuration](#kubernetes-configuration)
+    *   [Network Policies](./network-policy/README.md)
+    *   [Network Policies Helm Chart](./kubernetes/helm-charts/network-policies/README.md)
+*   [CI/CD Pipelines](#cicd-pipelines)
+    *   [GitHub Actions](./.github/workflows/README.md)
+    *   [Jenkins](./jenkins/README.md)
+*   [How to Use](#how-to-use)
+*   [Future Enhancements](#future-enhancements)
+
+## Project Structure
+
+The repository is organized as follows:
+
+```
+.
+├── .github/
+│   └── workflows/        # GitHub Actions CI/CD pipelines
+│       ├── ci.yml
+│       └── README.md
+├── backend/              # Backend application code
+│   ├── main.py
+│   ├── requirements.txt
+│   └── .gitkeep
+├── frontend/             # Frontend application code
+│   ├── app.js
+│   ├── index.html
+│   ├── style.css
+│   └── .gitkeep
+├── jenkins/              # Jenkinsfile and related CI/CD scripts
+│   ├── Jenkinsfile
+│   └── README.md
+├── kubernetes/           # Kubernetes manifests and configurations
+│   ├── configs/
+│   │   └── .gitkeep
+│   ├── deployments/
+│   │   └── .gitkeep
+│   ├── helm-charts/
+│   │   └── network-policies/       # Helm chart for Network Policies
+│   │       ├── Chart.yaml
+│   │       ├── values.yaml
+│   │       ├── templates/
+│   │       │   ├── networkpolicy.yaml
+│   │       │   └── _helpers.tpl
+│   │       ├── .helmignore
+│   │       └── README.md
+│   ├── ingresses/
+│   │   └── .gitkeep
+│   ├── namespaces/
+│   │   └── .gitkeep
+│   ├── network-policies/ # Specific K8s Network Policy YAMLs (can link to /network-policy)
+│   │   ├── README.md
+│   │   └── .gitkeep
+│   ├── services/
+│   │   └── .gitkeep
+│   ├── storage/
+│   │   └── .gitkeep
+│   └── README.md
+├── network-policy/       # Dedicated section for Network Policy examples and documentation
+│   ├── default-deny-all.yaml
+│   ├── allow-frontend-to-backend.yaml
+│   └── README.md
+└── README.md             # This main README file
+```
+
+## Frontend
+
+*   Location: [`./frontend/`](./frontend/)
+*   Description: Contains placeholder files for a simple frontend application.
+*   Technologies: (HTML, CSS, JavaScript - adaptable to React, Vue, Angular, etc.)
+
+## Backend
+
+*   Location: [`./backend/`](./backend/)
+*   Description: Contains placeholder files for a backend API.
+*   Technologies: (Python - adaptable to Flask, Django, Node.js/Express, Java/Spring Boot, etc.)
+
+## Kubernetes Configuration
+
+*   Location: [`./kubernetes/`](./kubernetes/)
+*   Description: Holds all Kubernetes manifest files (deployments, services, ingresses, configs, etc.).
+*   **Network Policies:**
+    *   A key focus of this portfolio. Detailed examples and explanations are in the [`./network-policy/README.md`](./network-policy/README.md) section.
+    *   Sample YAMLs are provided in [`./network-policy/`](./network-policy/).
+    *   The `kubernetes/network-policies/` directory can hold specific instances or link to the main ones.
+*   **Helm Charts:**
+    *   The primary Helm chart in this project is for managing Network Policies.
+    *   Location: [`./kubernetes/helm-charts/network-policies/`](./kubernetes/helm-charts/network-policies/)
+    *   See the [Network Policies Helm Chart README](./kubernetes/helm-charts/network-policies/README.md) for detailed usage instructions.
+
+## CI/CD Pipelines
+
+This project includes examples of CI/CD pipelines:
+
+*   **GitHub Actions:**
+    *   Location: [`./.github/workflows/`](./.github/workflows/)
+    *   See the [GitHub Actions README](./.github/workflows/README.md) for more details.
+    *   A sample workflow `ci.yml` provides a basic structure for build, test, and deployment steps.
+*   **Jenkins:**
+    *   Location: [`./jenkins/`](./jenkins/)
+    *   See the [Jenkins README](./jenkins/README.md) for more details.
+    *   A sample `Jenkinsfile` outlines a declarative pipeline.
+
+## How to Use
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd <repository-name>
+    ```
+2.  **Explore the sections:** Navigate through the directories to see the code and configurations.
+3.  **Frontend/Backend:**
+    *   Develop the placeholder applications further based on your chosen frameworks.
+4.  **Kubernetes:**
+    *   Ensure you have a Kubernetes cluster (e.g., Minikube, Kind, Docker Desktop K8s, or a cloud provider's K8s).
+    *   Apply manifests: `kubectl apply -f ./kubernetes/namespaces/your-namespace.yaml` (if you create one)
+    *   Apply Network Policies:
+        *   Manually: `kubectl apply -f ./network-policy/default-deny-all.yaml -n your-namespace`
+        *   Via Helm Chart: Navigate to `kubernetes/helm-charts/network-policies/` and use `helm install <release-name> . -n <namespace-defined-in-values>`. See the chart's README for more details.
+    *   Deploy applications using `kubectl apply -f ./kubernetes/deployments/` and `./kubernetes/services/`.
+5.  **CI/CD:**
+    *   **GitHub Actions:** Workflows will trigger automatically on push/pull_request to configured branches.
+    *   **Jenkins:** Set up a Jenkins server and configure a new pipeline job pointing to the `Jenkinsfile` in this repository.
+
+## Future Enhancements
+
+*   Develop full-fledged frontend and backend applications.
+*   Implement more complex Network Policy scenarios.
+*   Integrate with monitoring and logging tools (e.g., Prometheus, Grafana, ELK stack).
+*   Add automated security scanning to CI/CD pipelines.
+*   Expand Helm charts for full application deployment.
+*   Include examples of other SRE practices like SLOs/SLIs, incident management, etc.
+
+---
+
+This portfolio is a living project and will be updated as I explore and implement new concepts. Feel free to browse and provide feedback!

--- a/backend/.gitkeep
+++ b/backend/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,81 @@
+# Placeholder for backend Python (e.g., Flask/Django) application
+# You can replace this with your preferred backend language and framework.
+
+# Example: A simple Flask app
+"""
+from flask import Flask, jsonify
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return "Hello from Backend!"
+
+@app.route('/api/data')
+def get_data():
+    return jsonify({"message": "This is some data from the backend API", "value": 42})
+
+if __name__ == '__main__':
+    app.run(debug=True, host='0.0.0.0', port=5000)
+"""
+
+# Example: A simple Node.js Express app (if you prefer Node.js for backend)
+"""
+const express = require('express');
+const app = express();
+const port = 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello from Backend!');
+});
+
+app.get('/api/data', (req, res) => {
+  res.json({ message: 'This is some data from the backend API', value: 42 });
+});
+
+app.listen(port, () => {
+  console.log(`Backend app listening at http://localhost:${port}`);
+});
+"""
+
+# Example: A simple Java Spring Boot application structure (conceptual)
+/*
+package com.example.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class BackendApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(BackendApplication.class, args);
+    }
+}
+
+@RestController
+class ApiController {
+
+    @GetMapping("/")
+    public String home() {
+        return "Hello from Backend!";
+    }
+
+    @GetMapping("/api/data")
+    public java.util.Map<String, Object> getData() {
+        java.util.Map<String, Object> data = new java.util.HashMap<>();
+        data.put("message", "This is some data from the backend API");
+        data.put("value", 42);
+        return data;
+    }
+}
+*/
+
+def main():
+    print("Hello from Backend (Python Placeholder)!")
+    # Add your backend logic here
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,7 @@
+# Placeholder for backend Python dependencies
+# Example:
+# flask
+# requests
+
+# If using Node.js, this would be a package.json
+# If using Java, this would be a pom.xml or build.gradle

--- a/frontend/.gitkeep
+++ b/frontend/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,48 @@
+// Placeholder for frontend JavaScript code
+console.log("Hello from Frontend!");
+
+// Example: A simple React component (if you plan to use React)
+/*
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+function App() {
+  return (
+    <div>
+      <h1>Hello, Frontend!</h1>
+      <p>This is a placeholder React application.</p>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));
+*/
+
+// Example: A simple Vue component (if you plan to use Vue)
+/*
+import Vue from 'vue';
+
+new Vue({
+  el: '#app',
+  data: {
+    message: 'Hello, Frontend! This is a placeholder Vue application.'
+  },
+  template: '<h1>{{ message }}</h1>'
+});
+*/
+
+// Example: A simple Angular component (if you plan to use Angular)
+/*
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `
+    <h1>Hello, Frontend!</h1>
+    <p>This is a placeholder Angular application.</p>
+  `
+})
+export class AppComponent {
+  title = 'frontend-placeholder';
+}
+*/

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Frontend Placeholder</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="root">
+        <h1>Hello, Frontend!</h1>
+        <p>This is a placeholder HTML page.</p>
+        <p>You can link your JavaScript framework here or build a static site.</p>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,25 @@
+/* Placeholder for frontend CSS styles */
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 20px;
+    background-color: #f4f4f4;
+    color: #333;
+    text-align: center;
+}
+
+h1 {
+    color: #007bff;
+}
+
+p {
+    font-size: 1.1em;
+}
+
+#root {
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    display: inline-block;
+}

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -1,0 +1,134 @@
+// Jenkins Declarative Pipeline: Basic CI/CD Placeholder
+
+pipeline {
+    agent any // Or specify a specific agent (e.g., label 'docker', 'python')
+
+    environment {
+        // Define environment variables if needed
+        // EXAMPLE_VAR = "example_value"
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                script {
+                    // Checkout code from SCM (e.g., Git)
+                    // This is usually configured in the Jenkins job UI or through a Git SCM step
+                    echo 'Checking out code...'
+                    // Example: git url: 'YOUR_REPO_URL', branch: 'main'
+                    // For this placeholder, we assume code is already checked out by Jenkins
+                }
+            }
+        }
+
+        stage('Build Frontend (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Frontend Build...'
+                    // Example for a Node.js project:
+                    // dir('frontend') {
+                    //     sh 'npm install'
+                    //     sh 'npm run build'
+                    // }
+                }
+            }
+        }
+
+        stage('Test Frontend (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Frontend Tests...'
+                    // Example for a Node.js project:
+                    // dir('frontend') {
+                    //     sh 'npm test'
+                    // }
+                }
+            }
+        }
+
+        stage('Build Backend (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Backend Build (e.g., Python)...'
+                    // Example for a Python project:
+                    // dir('backend') {
+                    //     sh 'python -m venv venv'
+                    //     sh '. venv/bin/activate'
+                    //     sh 'pip install -r requirements.txt'
+                    //     // No explicit build step for simple Python, but could be packaging, etc.
+                    // }
+                }
+            }
+        }
+
+        stage('Test Backend (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Backend Tests (e.g., Python pytest)...'
+                    // Example for a Python project:
+                    // dir('backend') {
+                    //     sh '. venv/bin/activate' // If using a virtual environment
+                    //     sh 'pytest'
+                    // }
+                }
+            }
+        }
+
+        stage('Build Docker Image (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Docker Image Build...'
+                    // Example:
+                    // sh 'docker build -t myapp-frontend:latest ./frontend'
+                    // sh 'docker build -t myapp-backend:latest ./backend'
+                }
+            }
+        }
+
+        stage('Push Docker Image (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Docker Image Push to Registry...'
+                    // Example (requires Docker Hub credentials configured in Jenkins):
+                    // withCredentials([usernamePassword(credentialsId: 'dockerhub-credentials', usernameVariable: 'DOCKER_USER', passwordVariable: 'DOCKER_PASS')]) {
+                    //     sh 'docker login -u $DOCKER_USER -p $DOCKER_PASS'
+                    //     sh 'docker push myapp-frontend:latest'
+                    //     sh 'docker push myapp-backend:latest'
+                    // }
+                }
+            }
+        }
+
+        stage('Deploy to Kubernetes (Placeholder)') {
+            steps {
+                script {
+                    echo 'Simulating Deployment to Kubernetes...'
+                    // Example using kubectl (requires kubeconfig configured in Jenkins):
+                    // withKubeconfig([credentialsId: 'kubernetes-cluster-config']) {
+                    //     sh 'kubectl apply -f kubernetes/deployments/backend-deployment.yaml'
+                    //     sh 'kubectl apply -f kubernetes/services/backend-service.yaml'
+                    //     // Add other kubectl apply commands for frontend, ingress, etc.
+                    // }
+                    // Or using Helm:
+                    // sh 'helm upgrade --install my-release ./kubernetes/helm-charts/my-app-chart --values ./kubernetes/helm-charts/my-app-chart/values-prod.yaml'
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            echo 'Pipeline finished.'
+            // Clean up workspace, send notifications, etc.
+            // cleanWs()
+        }
+        success {
+            echo 'Pipeline succeeded!'
+            // mail to: 'team@example.com', subject: 'Build Successful: ${JOB_NAME} [${BUILD_NUMBER}]', body: 'Pipeline completed successfully.'
+        }
+        failure {
+            echo 'Pipeline failed.'
+            // mail to: 'team@example.com', subject: 'Build Failed: ${JOB_NAME} [${BUILD_NUMBER}]', body: 'Pipeline failed. Check console output.'
+        }
+    }
+}

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,17 @@
+# Jenkins Pipelines
+
+This directory contains `Jenkinsfile` examples or shared library configurations for CI/CD pipelines managed by Jenkins.
+
+## Purpose
+
+Jenkins is a powerful automation server that can be used to build, test, and deploy applications. `Jenkinsfile`s define these pipelines as code.
+
+## Examples
+
+- **Declarative Pipelines:** Modern, structured way to define Jenkins pipelines.
+- **Scripted Pipelines:** More flexible, Groovy-based pipeline definitions.
+- **Integration with GitHub:** Triggering Jenkins jobs from GitHub webhooks.
+- **Multi-branch Pipelines:** Automatically creating pipelines for different branches in a repository.
+- **Deployment Stages:** Defining stages for deploying to various environments (dev, staging, prod).
+
+This section will showcase how Jenkins can be leveraged for robust CI/CD automation, complementing or as an alternative to GitHub Actions.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,17 @@
+# Kubernetes Manifests
+
+This directory contains all Kubernetes manifest files (YAMLs) for deploying the application and its related services.
+
+## Structure
+
+- **/namespaces**: Contains namespace definitions.
+- **/deployments**: Contains deployment YAMLs for application components.
+- **/services**: Contains service YAMLs to expose applications.
+- **/ingresses**: Contains ingress YAMLs for external access.
+- **/configs**: Contains ConfigMap and Secret definitions.
+- **/storage**: Contains PersistentVolume and PersistentVolumeClaim definitions.
+- **/network-policies**: Contains NetworkPolicy definitions (this might link to or duplicate from the top-level `network-policy` directory, or be the primary location if preferred).
+- **/helm-charts**: This directory will house Helm charts for packaging and deploying applications.
+  - **/my-network-policy-chart**: Placeholder for the user-provided Network Policy Helm chart.
+
+This structured approach helps in managing and understanding the various components of the Kubernetes deployment.

--- a/kubernetes/configs/.gitkeep
+++ b/kubernetes/configs/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/kubernetes/deployments/.gitkeep
+++ b/kubernetes/deployments/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/kubernetes/helm-charts/network-policies/.helmignore
+++ b/kubernetes/helm-charts/network-policies/.helmignore
@@ -1,0 +1,46 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and absolute path matching.
+# E.g.
+#
+# .DS_Store
+# .git/
+# .gitignore
+# .gitmodules
+# .helmignore
+# charts/
+# examples/
+# README.md.gotmpl
+# test/
+# testdata/
+
+# Ignore common files
+.DS_Store
+.project
+.settings
+.idea/
+*.swp
+*.swo
+
+# Ignore Git files
+.git/
+.gitignore
+.gitattributes
+
+# Ignore CI/CD specific files if any
+.circleci/
+.travis.yml
+Jenkinsfile
+
+# Ignore test files within the chart itself if not part of templates
+tests/
+test/
+
+# Ignore temporary files
+tmp/
+*.tmp
+*.bak
+*.old
+
+# If you have a parent chart and this is a subchart, you might ignore its values if they are overridden by the parent
+# values.yaml.example # If you have example value files you don't want to package
+# README.md # If your README is for source control only and not for the packaged chart (though often it's included)

--- a/kubernetes/helm-charts/network-policies/Chart.yaml
+++ b/kubernetes/helm-charts/network-policies/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: network-policies
+description: A Helm chart for deploying Kubernetes Network Policies
+type: application # or library
+version: 0.1.0
+appVersion: "1.0.0" # Version of the app the chart deploys
+
+# Optional: Maintainer information
+maintainers:
+  - name: YourName # Replace with your name or org
+    email: your.email@example.com # Replace with your email
+
+# Optional: Keywords for discoverability
+keywords:
+  - kubernetes
+  - networkpolicy
+  - security
+  - networking
+
+# Optional: Home page URL for the chart or application
+# home: https://example.com/network-policies-chart
+
+# Optional: Source URLs for the chart
+# sources:
+#   - https://github.com/your-repo/your-chart-source # Replace with your repo if applicable
+
+# Optional: Icon URL
+# icon: https://example.com/icon.png

--- a/kubernetes/helm-charts/network-policies/README.md
+++ b/kubernetes/helm-charts/network-policies/README.md
@@ -1,0 +1,108 @@
+# Network Policies Helm Chart
+
+This Helm chart deploys Kubernetes NetworkPolicies based on the configurations defined in `values.yaml`.
+
+It allows for dynamic creation of policies to control ingress traffic to pods within a specified namespace.
+
+## Chart Structure
+
+-   **`Chart.yaml`**: Contains metadata about the chart (version, name, etc.).
+-   **`values.yaml`**: Default configuration values for the chart. This is where you define your network policy rules.
+-   **`templates/networkpolicy.yaml`**: The main Helm template that generates NetworkPolicy Kubernetes resources.
+-   **`templates/_helpers.tpl`**: Contains helper templates for generating labels, names, etc.
+-   **`.helmignore`**: Specifies files to ignore when packaging the chart.
+-   **`README.md`**: This file, providing an overview of the chart.
+
+## Configuration
+
+The primary way to configure this chart is by modifying the `values.yaml` file or by providing your own values file during installation/upgrade.
+
+### Key Configuration Sections in `values.yaml`:
+
+1.  **`namespace`**: (String) The Kubernetes namespace where these NetworkPolicies will be applied.
+2.  **`networkPolicies`**: (Object) Root object containing all policy definitions.
+    *   **`allowFromNamespaces`**: (Object) Defines policies that allow ingress from all pods in specified source namespaces to all pods in the target namespace (`.Values.namespace`).
+        *   Each key under `allowFromNamespaces` (e.g., `monitoring-stage`) represents a distinct policy set.
+            *   `enabled`: (Boolean) Set to `true` to generate this policy.
+            *   `fromNamespaces`: (List of Strings) A list of source namespace names.
+            *   `ports`: (List of Objects) A list of ports to allow traffic on.
+                *   `protocol`: (String) e.g., `TCP`, `UDP`.
+                *   `port`: (Integer) Port number.
+    *   **`applications`**: (Object) Defines policies targeting specific applications (pods selected by labels) within the target namespace.
+        *   **`allowExternalIPblock`**: (Object, Optional) A special configuration to allow traffic from external IP CIDRs to a specific application.
+            *   `enabled`: (Boolean) Set to `true` to generate this policy.
+            *   `labels`: (Object) Labels to select the target pods (e.g., `app: service-center`).
+            *   `targetsIPblocks`: (Object)
+                *   `externalSubnets`: (List of Strings) CIDR blocks (e.g., `"0.0.0.0/0"`).
+                *   `ports`: (List of Objects) Ports to allow.
+        *   **Other keys under `applications`** (e.g., `allowIngress` or your custom application name): Each key represents a set of ingress rules for a specific application (target pods).
+            *   `enabled`: (Boolean) Set to `true` to generate policies for this application.
+            *   `labels`: (Object) Labels to select the target pods this policy applies to (e.g., `app: service-center`).
+            *   `namespace`: (String, Optional) Namespace of the target pods (defaults to `.Values.namespace`).
+            *   `with`: (List of Objects) Defines communication rules. Each item in this list creates a separate NetworkPolicy.
+                *   `targets`: (Object) Describes the source of allowed traffic.
+                    *   `namespace`: (String, Optional) Namespace of the source pods. If different from the target pod's namespace, a `namespaceSelector` will be used. Defaults to the target application's namespace.
+                    *   `labels`: (List of Strings) A list of `app` labels for the source pods. Each label will generate a policy allowing traffic from pods with `app: <label-value>`.
+                    *   `ports`: (List of Objects) Ports to allow.
+
+## How to Use
+
+### Prerequisites
+
+-   Helm 3 installed.
+-   Kubernetes cluster configured with `kubectl`.
+
+### Installation
+
+1.  **Navigate to the chart directory (or use repository if added):**
+    ```bash
+    cd path/to/kubernetes/helm-charts/network-policies
+    ```
+
+2.  **Lint the chart (optional, good practice):**
+    ```bash
+    helm lint .
+    ```
+
+3.  **Perform a dry run (to see what would be generated):**
+    ```bash
+    helm install my-release . --dry-run --debug -n <target-namespace-from-values-or-override>
+    # Example with values from a file:
+    # helm install my-release . --dry-run --debug -f my-custom-values.yaml -n <namespace>
+    ```
+
+4.  **Install the chart:**
+    ```bash
+    helm install my-netpols . -n <target-namespace-from-values-or-override>
+    # Example: If values.yaml has `namespace: platform`
+    # helm install my-netpols . -n platform
+
+    # To override values during installation:
+    # helm install my-netpols . -n platform --set networkPolicies.applications.allowExternalIPblock.enabled=false
+    ```
+
+### Upgrading the Chart
+
+If you modify the `values.yaml` or the templates:
+
+```bash
+helm upgrade my-netpols . -n <target-namespace>
+```
+
+### Uninstalling the Chart
+
+```bash
+helm uninstall my-netpols -n <target-namespace>
+```
+
+## Templating Logic Overview
+
+-   **Section 1 (`allowFromNamespaces`):** Creates policies allowing all pods in specified `fromNamespaces` to communicate with all pods in the `{{ .Values.namespace }}` on given ports.
+-   **Section 2 (`allowExternalIPblock`):** Creates a policy allowing traffic from specified `externalSubnets` to pods matching `labels.app` within `{{ .Values.namespace }}` on given ports.
+-   **Section 3 (Other `applications`):** For each enabled application configuration under `networkPolicies.applications` (excluding `allowExternalIPblock`):
+    -   It iterates through the `labels` of the *target* application (the pod group the policy is for).
+    -   It then iterates through the `with` array, which defines *sources*.
+    -   For each source defined in `with.targets.labels`, it creates a NetworkPolicy.
+    -   This policy allows ingress to the *target* pods (selected by `applications.<appKey>.labels`) from *source* pods (selected by `with.targets.labels.app` and `with.targets.namespace`).
+
+This structure allows for granular control over ingress traffic based on namespaces and pod labels. Ensure your pod deployments have the corresponding labels for these policies to take effect.

--- a/kubernetes/helm-charts/network-policies/templates/_helpers.tpl
+++ b/kubernetes/helm-charts/network-policies/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Common labels
+*/}}
+{{- define "network-policies.labels" -}}
+helm.sh/chart: {{ include "network-policies.chart" . }}
+{{ include "network-policies.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "network-policies.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "network-policies.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "network-policies.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "network-policies.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate a name for a network policy.
+Input: A map with "name" key for the base name.
+Example: {{ include "network-policies.policyName" (dict "name" "allow-ingress") }}
+*/}}
+{{- define "network-policies.policyName" -}}
+{{- printf "%s-%s" (include "network-policies.fullname" .) .name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/kubernetes/helm-charts/network-policies/templates/networkpolicy.yaml
+++ b/kubernetes/helm-charts/network-policies/templates/networkpolicy.yaml
@@ -1,0 +1,124 @@
+{{- $np := .Values.networkPolicies -}}
+{{- $myns := .Values.namespace -}}
+{{/* $appName is defined locally in section 2, so removing the global one. */}}
+
+{{- /* 1. Loop over each named allowFromNamespaces entry */}}
+{{- with $np.allowFromNamespaces }}
+  {{- range $name, $global := . }}
+    {{- if $global.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "network-policies.policyName" (dict "name" (printf "allow-from-%s" $name) "Chart" $.Chart "Release" $.Release "Values" $.Values) }}
+  namespace: {{ $myns }}
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: {} # Apply to all pods in the namespace
+  policyTypes:
+    - Ingress
+  ingress:
+  {{- range $ns := $global.fromNamespaces }}
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ $ns }}
+        podSelector: {} # Allow from all pods in the selected namespace
+      {{- if $global.ports }}
+      ports:
+      {{- range $p := $global.ports }}
+        - protocol: {{ $p.protocol }}
+          port: {{ $p.port }}
+      {{- end }}
+      {{- end }}
+  {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /* 2. Loop for allowExternalIPblock (specific handling) */}}
+{{- if and $np.applications.allowExternalIPblock $np.applications.allowExternalIPblock.enabled }}
+{{- $appConfig := $np.applications.allowExternalIPblock }}
+{{- $appNameForPolicy := $appConfig.labels.app }}
+{{- $targetAccess := $appConfig.targetsIPblocks }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "network-policies.policyName" (dict "name" (printf "allow-external-to-%s" $appNameForPolicy) "Chart" $.Chart "Release" $.Release "Values" $.Values) }}
+  namespace: {{ $myns }}
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ $appNameForPolicy }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      {{- range $cidr := $targetAccess.externalSubnets }}
+      - ipBlock:
+          cidr: {{ $cidr }}
+      {{- end }}
+      {{- if $targetAccess.ports }}
+      ports:
+      {{- range $p := $targetAccess.ports }}
+        - protocol: {{ $p.protocol }}
+          port: {{ $p.port }}
+      {{- end }}
+      {{- end }}
+{{- end }}
+
+
+{{- /* 3. Loop over all other enabled applications in networkPolicies.applications */}}
+{{- range $appNameKey, $app := $np.applications }}
+  {{- /* Skip allowExternalIPblock as it's handled above, and only process if enabled and has 'with' communications defined */}}
+  {{- if and (ne $appNameKey "allowExternalIPblock") $app.enabled $app.with }}
+    {{- range $appLabelKey, $appLabelValue := $app.labels }} {{/* This iterates over the labels of the pod the policy is FOR */}}
+      {{- range $comm := $app.with }} {{/* This iterates over the communication rules */}}
+        {{- $target := $comm.targets }}
+        {{- $targetNS := $target.namespace | default $app.namespace | default $myns }}
+        {{- range $sourcePodLabel := $target.labels }} {{/* This iterates over the labels of the SOURCE pods */}}
+---
+# Policy for {{ $appLabelValue }} (as {{ $appLabelKey }}) FROM {{ $sourcePodLabel }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "network-policies.policyName" (dict "name" (printf "allow-%s-to-%s" $sourcePodLabel $appLabelValue) "Chart" $.Chart "Release" $.Release "Values" $.Values) }}
+  namespace: {{ $myns }} # Policy is created in the main namespace defined in values.yaml
+  labels:
+    {{- include "network-policies.labels" . | nindent 4 }}
+spec:
+  podSelector: # This policy applies to pods with these labels
+    matchLabels:
+      {{ $appLabelKey }}: {{ $appLabelValue }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+      - {{- if eq $targetNS $myns }} # If source is in the same namespace
+        podSelector:
+          matchLabels:
+            app: {{ $sourcePodLabel }}
+        {{- else }} # If source is in a different namespace
+        namespaceSelector:
+          matchLabels:
+            kubernetes.io/metadata.name: {{ $targetNS }}
+        podSelector:
+          matchLabels:
+            app: {{ $sourcePodLabel }}
+        {{- end }}
+      {{- if $target.ports }}
+      ports:
+      {{- range $p := $target.ports }}
+        - protocol: {{ $p.protocol }}
+          port: {{ $p.port }}
+      {{- end }}
+      {{- end }}
+        {{- end }}  {{/* end sourcePodLabel loop */}}
+      {{- end }}    {{/* end comm loop */}}
+    {{- end }}      {{/* end app.labels loop */}}
+  {{- end }}        {{/* end if condition for app */}}
+{{- end }}          {{/* end applications loop */}}

--- a/kubernetes/helm-charts/network-policies/values.yaml
+++ b/kubernetes/helm-charts/network-policies/values.yaml
@@ -1,0 +1,95 @@
+# values.yaml
+namespace: platform
+
+networkPolicies:
+  allowFromNamespaces:
+    monitoring-stage:
+      enabled: true
+      fromNamespaces:
+        - monitoring
+      ports:
+        - protocol: TCP
+          port: 9100
+        - protocol: TCP
+          port: 9090
+        - protocol: TCP
+          port: 8080
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 8686
+
+    # stage2:
+    #   enabled: true
+    #   applyOnNamespace: netpol-walletapps # Note: applyOnNamespace is not used in the current template, namespace is global via `namespace:`
+    #   fromNamespaces:
+    #     - metrics
+    #     - audit
+      # ports:
+      #   - protocol: TCP
+      #     port: 9200
+
+  applications:
+    allowExternalIPblock:
+      enabled: true
+      labels:
+        app: service-center # This is the application the policy *applies to*
+      targetsIPblocks: # This structure implies these are sources allowed *to* the app
+        externalSubnets:
+          - "0.0.0.0/0"
+        ports:
+          - protocol: TCP
+            port: 5100
+          - protocol: TCP
+            port: 8100
+          - protocol: TCP
+            port: 9100
+
+    # This section seems to define policies where 'service-center' (and others if added)
+    # needs to allow ingress from other specific internal services.
+    # The template structure for "3. Loop enabled applications" will handle this.
+    # We'll assume 'allowIngress' is a grouping name, and each entry under it is an app definition.
+    # For clarity, let's rename 'allowIngress' to 'internalAppComms' or similar if it represents multiple apps.
+    # Or, if 'service-center' is the *only* app configured here, the structure is fine.
+    # The provided template seems to iterate over `networkPolicies.applications` for the third block.
+    # So, 'allowExternalIPblock' and 'allowIngress' will be treated as two distinct app configurations by the template.
+    allowIngress: # This will be treated as an $appName in the template loop
+      enabled: true
+      labels: # These are the labels of the pods this policy *applies to*
+        app: service-center # e.g. service-center allows ingress from service1
+      namespace: platform # Namespace of the pods this policy applies to (can be overridden by target.namespace for source)
+      with: # Defines communication rules
+        - targets: # Describes the source of traffic
+            namespace: platform # Namespace of the source pods
+            labels: # Labels of the source pods
+              - service1 # This will become $label in the template
+            ports:
+              - protocol: TCP
+                port: 5100
+              - protocol: TCP
+                port: 8100
+              - protocol: TCP
+                port: 9100
+        # Example for another source for the same 'service-center' app:
+        # - targets:
+        #     namespace: another-ns
+        #     labels:
+        #       - service2
+        #     ports:
+        #       - protocol: TCP
+        #         port: 1234
+
+    # Example for another application requiring ingress policies:
+    # another-app:
+    #   enabled: true
+    #   labels:
+    #     app: another-app-pod-label
+    #   namespace: platform
+    #   with:
+    #     - targets:
+    #         namespace: platform
+    #         labels:
+    #           - service-center # Allow 'another-app' to be accessed by 'service-center'
+    #         ports:
+    #           - protocol: TCP
+    #             port: 8888

--- a/kubernetes/ingresses/.gitkeep
+++ b/kubernetes/ingresses/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/kubernetes/namespaces/.gitkeep
+++ b/kubernetes/namespaces/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/kubernetes/network-policies/.gitkeep
+++ b/kubernetes/network-policies/.gitkeep
@@ -1,0 +1,2 @@
+# This file is to ensure the directory is created. You can delete it later.
+# This directory can contain raw NetworkPolicy YAMLs or be linked from the main /network-policy directory.

--- a/kubernetes/network-policies/README.md
+++ b/kubernetes/network-policies/README.md
@@ -1,0 +1,15 @@
+# Kubernetes Network Policies
+
+This directory contains specific NetworkPolicy manifest files.
+
+For a general overview of Network Policies and how they are used in this project, please see the [main Network Policy documentation](../../network-policy/README.md).
+
+## Sample Policies included here:
+
+*   Refer to policies in the top-level `network-policy` directory or copy/link them here.
+    *   `default-deny-all.yaml`: A policy to deny all ingress and egress traffic by default in a namespace.
+    *   `allow-frontend-to-backend.yaml`: An example policy allowing frontend pods to communicate with backend pods, and backend pods to a database.
+
+You can apply these policies using `kubectl apply -f <filename>.yaml -n <namespace>`.
+
+Remember to tailor these policies (namespaces, labels, ports) to your specific application deployment.

--- a/kubernetes/services/.gitkeep
+++ b/kubernetes/services/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/kubernetes/storage/.gitkeep
+++ b/kubernetes/storage/.gitkeep
@@ -1,0 +1,1 @@
+# This file is to ensure the directory is created. You can delete it later.

--- a/network-policy/README.md
+++ b/network-policy/README.md
@@ -1,0 +1,30 @@
+# Kubernetes Network Policies
+
+This section of the portfolio demonstrates the implementation and importance of Kubernetes Network Policies.
+
+## Overview
+
+Kubernetes Network Policies are specifications of how groups of pods are allowed to communicate with each other and other network endpoints. They are a powerful tool for enforcing network segmentation and security within a Kubernetes cluster.
+
+Network Policies are Namespace-scoped resources. They use labels to select pods and define rules which specify what traffic is allowed to and from those pods.
+
+## Importance
+
+- **Security:** By default, all pods in a Kubernetes cluster can communicate with each other. Network Policies allow you to restrict this communication, reducing the attack surface and preventing lateral movement in case of a compromise.
+- **Isolation:** They enable you to isolate different applications or tenants running in the same cluster, ensuring that they cannot interfere with each other.
+- **Compliance:** For many regulatory frameworks, network segmentation is a requirement. Network Policies help in achieving and demonstrating compliance.
+
+## Implementation in this Project
+
+This project will showcase practical examples of Network Policies, including:
+
+- Default deny policies.
+- Allowing traffic from specific namespaces or pods.
+- Allowing traffic to external services.
+- Policies for ingress and egress traffic.
+
+The policies will be defined as YAML files and can be applied to a Kubernetes cluster using `kubectl apply -f <policy-file.yaml>`.
+
+We will also explore managing Network Policies using Helm charts for easier deployment and versioning.
+
+Stay tuned for concrete examples and configurations!

--- a/network-policy/allow-frontend-to-backend.yaml
+++ b/network-policy/allow-frontend-to-backend.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-to-backend
+  namespace: application # Assuming your app runs in the 'application' namespace
+spec:
+  podSelector:
+    matchLabels:
+      app: backend # This policy applies to pods labeled 'app: backend'
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend # Allow traffic from pods labeled 'app: frontend'
+    ports:
+    - protocol: TCP
+      port: 8080 # Assuming backend listens on port 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-backend-to-database # Example: Backend to Database
+  namespace: application # Assuming your app runs in the 'application' namespace
+spec:
+  podSelector:
+    matchLabels:
+      app: backend # This policy applies to pods labeled 'app: backend'
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: database # Allow traffic to pods labeled 'app: database'
+    ports:
+    - protocol: TCP
+      port: 5432 # Assuming database (e.g., PostgreSQL) listens on port 5432
+  # Note: You might also need an egress policy for the frontend if it needs to talk to external services
+  # or an ingress policy for the frontend if it needs to receive external traffic (usually handled by Ingress controller).

--- a/network-policy/default-deny-all.yaml
+++ b/network-policy/default-deny-all.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: default # Apply this policy to the 'default' namespace, or change as needed
+spec:
+  podSelector: {} # An empty podSelector selects all pods in the namespace
+  policyTypes:
+  - Ingress
+  - Egress
+  # This policy has no rules, so it denies all ingress and egress traffic
+  # for all pods in the namespace it's applied to.
+  # This is a common starting point for a secure setup.
+  # You would then add other policies to allow specific traffic.


### PR DESCRIPTION
This commit establishes the foundational directory layout and placeholder files for a comprehensive Full Stack & SRE portfolio project. It includes:

- Frontend and Backend application placeholders.
- Kubernetes manifest structure, including raw Network Policy examples.
- A fully implemented Helm chart for deploying configurable Network Policies, based on user-provided templates and values.
- CI/CD pipeline examples (placeholders) for GitHub Actions and Jenkins.
- Detailed README files for overall guidance, section-specific information, and Helm chart usage.

The project is structured to showcase skills in full-stack development, Kubernetes (with a strong emphasis on Network Policies and Helm), and SRE automation practices.